### PR TITLE
fix: prevent tooltip overlay from locking window dragging on macOS

### DIFF
--- a/src/styles/sections/tooltip.css
+++ b/src/styles/sections/tooltip.css
@@ -1,6 +1,9 @@
 .persian-calendar--tooltip-wrapper {
 	position: absolute;
-	inset: 0;
+	top: 0;
+	left: 0;
+	width: 0;
+	height: 0;
 	pointer-events: none;
 	z-index: 9999;
 }
@@ -18,7 +21,7 @@
 	font-size: 12px;
 	line-height: 1.6;
 	box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
-	pointer-events: auto;
+	pointer-events: none;
 }
 
 .persian-calendar__tooltip-event {


### PR DESCRIPTION
The events tooltip mounted a wrapper element (.persian-calendar--tooltip-wrapper) styled `position: absolute; inset: 0; z-index: 9999` onto the document body. `inset: 0` stretched it across the entire window, including the macOS title bar. Once any day with an event was hovered or clicked, this full-viewport overlay was created and left in the DOM (only its child was toggled with `display: none`).

On macOS an element covering the window's draggable title-bar region blocks the OS-level window drag; `pointer-events: none` does not exempt an element from that hit-test. As a result the window could no longer be moved (e.g. between monitors) after interacting with the calendar, until the app lost focus.

The tooltip only needs a positioned anchor, not a full-screen layer. Give the wrapper a zero footprint (top/left 0, width/height 0) so it never covers the title bar, and make the tooltip itself non-interactive (pointer-events: none). Tooltip positioning is unchanged: the tooltip is still positioned relative to the wrapper's top-left corner at the page origin.

Fixes #65